### PR TITLE
Fix deprecated vim mappings for git gutter

### DIFF
--- a/vim/plugins/gitgutter.vim
+++ b/vim/plugins/gitgutter.vim
@@ -10,8 +10,8 @@ let g:gitgutter_sign_modified = '⇔'
 let g:gitgutter_sign_removed = '⇐'
 let g:gitgutter_sign_modified_removed = '⇎'
 
-nmap ]d <Plug>GitGutterNextHunk
-nmap [d <Plug>GitGutterPrevHunk
+nmap ]d <Plug>(GitGutterNextHunk)
+nmap [d <Plug>(GitGutterPrevHunk)
 
 function! ToggleGitGutterMode()
   if g:gitgutter_diff_base == ''


### PR DESCRIPTION
The `<Plug>…` maps have been deprecated in favour of `<Plug>(…)`.

https://github.com/airblade/vim-gitgutter/commit/0469b8435ab8b2f25302ef04136591934730e56a