### PR TITLE
Set ERB template filename in __database_yml

### DIFF
--- a/shell/aliases/rails.sh
+++ b/shell/aliases/rails.sh
@@ -113,7 +113,7 @@ function rubocop-branch {
 
 function __database_yml {
   if [[ -f config/database.yml ]]; then
-    ruby -ryaml -rerb -e "puts YAML::load(ERB.new(IO.read('config/database.yml')).result)['${RAILS_ENV:-development}']['$1']"
+    ruby -ryaml -rerb -e "t = ERB.new(IO.read('config/database.yml')); t.filename = 'config/database.yml'; puts YAML::load(t.result)['${RAILS_ENV:-development}']['$1']"
   fi
 }
 


### PR DESCRIPTION
This allows `require_relative` to work in `database.yml`. An app I'm working on needs to require an environment related file at the top of our `database.yml`.

https://stackoverflow.com/questions/12290948/how-do-i-find-the-path-of-a-template-file-using-erb